### PR TITLE
Stop publishing to artifactory

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -10,16 +10,6 @@ publishing {
             artifactId 'ida-gradle'
         }
     }
-
-    repositories {
-        maven {
-            credentials {
-                username "${System.env.ARTIUSER}"
-                password "${System.env.ARTIPASSWORD}"
-            }
-            url "https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/libs-release-local"
-        }
-    }
 }
 
 group = "uk.gov.ida"


### PR DESCRIPTION
Bintray is the source of truth now.

Bintray is made available via whitelisted-repos on artifactory, so we
still pull dependencies down using artifactory, but we only need to
push dependencies to bintray.